### PR TITLE
Upgrade for compatibility with React 0.14+

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "chai": "1.10.0",
     "jsdom": "1.4.1",
     "mocha": "2.0.1",
-    "react": ">=0.12.0"
+    "react": ">=0.14.0",
+    "react-addons-pure-render-mixin": ">=0.14.0",
+    "react-addons-test-utils": ">=0.14.0",
+    "react-dom": ">=0.14.0"
   }
 }

--- a/src/SuitCSS.js
+++ b/src/SuitCSS.js
@@ -1,10 +1,10 @@
 'use strict';
 
-import React from 'react/addons';
+import React from 'react';
+import PureRenderMixin from 'react-addons-pure-render-mixin';
 import { camel, squish } from 'case';
 
 let { PropTypes } = React;
-let { PureRenderMixin } = React.addons;
 
 let SuitCSS = React.createClass({
 

--- a/src/test/SuitCSS-test.js
+++ b/src/test/SuitCSS-test.js
@@ -1,6 +1,9 @@
 'use strict';
 
 import { jsdom } from 'jsdom';
+import React from 'react'
+import { findDOMNode } from 'react-dom'
+import TestUtils from 'react-addons-test-utils'
 global.document = jsdom('');
 global.window = document.parentWindow;
 global.navigator = {};
@@ -9,9 +12,6 @@ navigator.userAgent = 'node';
 import { expect } from 'chai';
 
 describe('SuitCSS', function() {
-  import React from 'react/addons';
-  let {TestUtils} = React.addons;
-
   import SuitCSS from '../SuitCSS';
 
   let component = TestUtils.renderIntoDocument(
@@ -49,8 +49,8 @@ describe('SuitCSS', function() {
     />
   );
 
-  let componentEl = component.getDOMNode();
-  let buttonComponentEl = buttonComponent.getDOMNode();
+  let componentEl = findDOMNode(component);
+  let buttonComponentEl = findDOMNode(buttonComponent);
 
   it('has base class', function() {
     expect(elementHasClass(componentEl, 'Component')).to.be.true;


### PR DESCRIPTION
With React 0.14, functionality previously supported by the `react/addons` package has been extracted [into separate add-on packages](https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#two-packages-react-and-react-dom). This commit updates this package to use the version of  `PureRenderMixin` now found in the `react-addons-pure-render-mixin` package.
